### PR TITLE
refactor: 统一硬盘扩容tip内容

### DIFF
--- a/docs/guide/cloud/disk.md
+++ b/docs/guide/cloud/disk.md
@@ -85,6 +85,17 @@ resize2fs /dev/sda1
 
 </Tabs>
 
+:::tip
+运行growpart命令时，如果提示unexpected output in sfdisk --version [sfdisk，来自 util-linux x.x.x]
+
+这是因为中文版操作系统使用了非en_US.UTF-8的字符编码类型，请在执行前运行下方命令
+```
+LANG=en_US.UTF-8
+```
+
+由于win硬盘格式ntfs，win的盘换系统到ubuntu后，可能会产生一定识别问题
+:::
+
 ### 新增硬盘并挂载
 
 **使用 `fdisk -l `命令根据大小及其他信息查看要新增的云盘**，本例子中要新建的加的硬盘为 /dev/sdb

--- a/docs/rcs/practice/disk.md
+++ b/docs/rcs/practice/disk.md
@@ -86,10 +86,14 @@ resize2fs /dev/sda1
 </Tabs>
 
 :::tip
-注意：如果您把系统设置成了中文，在运行growpart命令之前必须先运行：LANG=en_US.UTF-8
-，否则会报错如： unexpected output in sfdisk --version
+运行growpart命令时，如果提示unexpected output in sfdisk --version [sfdisk，来自 util-linux x.x.x]
 
-由于win硬盘格式ntfs,win的盘换系统到ubuntu后,可能会产生一定识别问题
+这是因为中文版操作系统使用了非en_US.UTF-8的字符编码类型，请在执行前运行下方命令
+```
+LANG=en_US.UTF-8
+```
+
+由于win硬盘格式ntfs，win的盘换系统到ubuntu后，可能会产生一定识别问题
 :::
 
 ### 新增硬盘并挂载

--- a/docs/rgs/practice/disk.md
+++ b/docs/rgs/practice/disk.md
@@ -86,10 +86,14 @@ resize2fs /dev/sda1
 </Tabs>
 
 :::tip
-注意：如果您把系统设置成了中文，在运行growpart命令之前必须先运行：LANG=en_US.UTF-8
-，否则会报错如： unexpected output in sfdisk --version
+运行growpart命令时，如果提示unexpected output in sfdisk --version [sfdisk，来自 util-linux x.x.x]
 
-由于win硬盘格式ntfs,win的盘换系统到ubuntu后,可能会产生一定识别问题
+这是因为中文版操作系统使用了非en_US.UTF-8的字符编码类型，请在执行前运行下方命令
+```
+LANG=en_US.UTF-8
+```
+
+由于win硬盘格式ntfs，win的盘换系统到ubuntu后，可能会产生一定识别问题
 :::
 
 ### 新增硬盘并挂载

--- a/docs/support.md
+++ b/docs/support.md
@@ -219,10 +219,16 @@ resize2fs /dev/sda1
 </TabItem>
 
 </Tabs>
-:::tip
-注意：如果您把系统设置成了中文，在运行growpart命令之前必须先运行：LANG=en_US.UTF-8，否则会报错如： unexpected output in sfdisk --version
 
-由于win硬盘格式ntfs,win的盘换系统到ubuntu后,可能会产生一定识别问题
+:::tip
+运行growpart命令时，如果提示unexpected output in sfdisk --version [sfdisk，来自 util-linux x.x.x]
+
+这是因为中文版操作系统使用了非en_US.UTF-8的字符编码类型，请在执行前运行下方命令
+```
+LANG=en_US.UTF-8
+```
+
+由于win硬盘格式ntfs，win的盘换系统到ubuntu后，可能会产生一定识别问题
 :::
 
 #### 新增硬盘并挂载


### PR DESCRIPTION
1. 在其他字符编码环境下可能出现 unexpected output in sfdisk --version 是 cloud-utils 之前的问题已经被修复了，但是部分系统软件源仍为有该问题的版本
2. `由于win硬盘格式ntfs，win的盘换系统到ubuntu后，可能会产生一定识别问题` 该句话我只是做保留

```release-note
统一硬盘扩容tip内容
``` 